### PR TITLE
Fix missing StringIterator definitions

### DIFF
--- a/experimental/libbox/string_iterator_alias.go
+++ b/experimental/libbox/string_iterator_alias.go
@@ -1,0 +1,5 @@
+package libbox
+
+import cb "github.com/sagernet/sing-box/experimental/commonbox"
+
+type StringIterator = cb.StringIterator

--- a/experimental/rocketbox/string_iterator_alias.go
+++ b/experimental/rocketbox/string_iterator_alias.go
@@ -1,0 +1,5 @@
+package rocketbox
+
+import cb "github.com/sagernet/sing-box/experimental/commonbox"
+
+type StringIterator = cb.StringIterator


### PR DESCRIPTION
## Summary
- alias `StringIterator` in `libbox`
- alias `StringIterator` in `rocketbox`

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*