### PR TITLE
Fix gobind binding for rocketbox/libbox

### DIFF
--- a/experimental/libbox/string_iterator_alias.go
+++ b/experimental/libbox/string_iterator_alias.go
@@ -1,5 +1,11 @@
 package libbox
 
-import cb "github.com/sagernet/sing-box/experimental/commonbox"
-
-type StringIterator = cb.StringIterator
+// StringIterator defines a simple iterator over strings.
+//
+// It matches the commonbox.StringIterator interface so implementations of
+// that interface automatically satisfy this one as well.
+type StringIterator interface {
+	Len() int32
+	HasNext() bool
+	Next() string
+}

--- a/experimental/rocketbox/string_iterator_alias.go
+++ b/experimental/rocketbox/string_iterator_alias.go
@@ -1,5 +1,11 @@
 package rocketbox
 
-import cb "github.com/sagernet/sing-box/experimental/commonbox"
-
-type StringIterator = cb.StringIterator
+// StringIterator defines a simple iterator over strings.
+//
+// It mirrors the commonbox.StringIterator interface so existing implementations
+// remain compatible.
+type StringIterator interface {
+	Len() int32
+	HasNext() bool
+	Next() string
+}


### PR DESCRIPTION
## Summary
- define `StringIterator` interfaces inside both libbox and rocketbox packages to avoid cross-package alias issues

## Testing
- `go vet ./...` *(fails: dial tcp 172.24.0.3:8080: connect: no route to host)*