### PR TITLE
Fix missing Setup wrapper

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -1,0 +1,12 @@
+package box
+
+import cb "github.com/sagernet/sing-box/experimental/commonbox"
+
+// SetupOptions defines parameters for setting up global paths and user info.
+type SetupOptions = cb.SetupOptions
+
+// Setup initializes package-level variables for base, working, and temp paths.
+// It delegates to experimental/commonbox.Setup for the actual implementation.
+func Setup(options *SetupOptions) error {
+	return cb.Setup(options)
+}


### PR DESCRIPTION
## Summary
- add `SetupOptions` alias and `Setup` wrapper in box package

## Testing
- `go vet ./...` *(fails: This environment doesn't have network access after setup)*