### PR TITLE
Expose Setup API for libbox

### DIFF
--- a/experimental/libbox/setup.go
+++ b/experimental/libbox/setup.go
@@ -1,0 +1,12 @@
+package libbox
+
+import cb "github.com/sagernet/sing-box/experimental/commonbox"
+
+// SetupOptions defines parameters for setting up global paths and user info.
+type SetupOptions = cb.SetupOptions
+
+// Setup initializes package-level variables for base, working, and temp paths.
+// It delegates to experimental/commonbox.Setup for the actual implementation.
+func Setup(options *SetupOptions) error {
+	return cb.Setup(options)
+}


### PR DESCRIPTION
## Summary
- expose `Setup` and `SetupOptions` via `libbox` so mobile builds can configure paths

## Testing
- `go vet ./...` *(fails: no route to host)*